### PR TITLE
Fixed README to correct for argument order reversal in setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ create an instance of ofxGifEncoder
 		
 call setup 
 	
-	gifEncoder.setup(frameW, frameH, nColors, frameDuration);
+	gifEncoder.setup(frameW, frameH, frameDuration, nColors);
+	
+(frameDuration is a float in seconds and nColors is an int from 0 to 256.)
 
 optionally  :) (see dithering patterns on the h file)
 		


### PR DESCRIPTION
This should fix the discussion we were just having in Issue #2.
