### PR TITLE
Changed and improved reset to clear functions, added class for ofxGifFrame

### DIFF
--- a/src/ofxGifEncoder.cpp
+++ b/src/ofxGifEncoder.cpp
@@ -75,10 +75,18 @@ void ofxGifEncoder::addFrame(unsigned char *px, int _w, int _h, int _bitsPerPixe
             break;
     }
     
-    unsigned char * temp = new unsigned char[w * h * nChannels];
-    memcpy(temp, px, w * h * nChannels);
-    ofxGifFrame * gifFrame   = ofxGifEncoder::createGifFrame(temp, w, h, _bitsPerPixel, tempDuration) ;
+	
+	ofxGifFrame * gifFrame    = new ofxGifFrame();
+    gifFrame->pixels          = new unsigned char[w * h * nChannels];
+	memcpy( gifFrame->pixels, px, w * h * nChannels);
+    gifFrame->width           = w; 
+    gifFrame->height          = h;
+    gifFrame->duration        = tempDuration;
+    gifFrame->bitsPerPixel    = _bitsPerPixel;
+	
+	
     frames.push_back(gifFrame);
+	
 }
 
 void ofxGifEncoder::setNumColors(int _nColors){
@@ -176,6 +184,8 @@ void ofxGifEncoder::doSave() {
 	
 	FreeImage_Unload(bmp);
 	FreeImage_CloseMultiBitmap(multi); 
+	
+	clear();
 }
  
 // from ofimage
@@ -200,8 +210,10 @@ void ofxGifEncoder::exit() {
     stop();
 }
 
-void ofxGifEncoder::reset() {
-    frames.clear();
+void ofxGifEncoder::clear() {
+	for(vector<ofxGifFrame*>::const_iterator it = frames.begin(); it != frames.end(); it++) delete *it;
+	frames.clear();
+    stop();
 }
 
 

--- a/src/ofxGifEncoder.h
+++ b/src/ofxGifEncoder.h
@@ -52,7 +52,7 @@ class ofxGifEncoder: public ofThread {
         void start() {startThread(true, false);}
         void stop() {stopThread();}
         void exit();
-		void reset();
+		void clear();
         
         // if no duration is specified, we'll use default (from setup())
         void addFrame(ofImage & image, float duration = 0.f);        

--- a/src/ofxGifFrame.h
+++ b/src/ofxGifFrame.h
@@ -1,0 +1,30 @@
+/*
+ *  ofxGifFrame.h
+ */
+
+
+#ifndef OFXGIFFR
+#define OFXGIFFR
+
+#include "ofMain.h"
+
+class ofxGifFrame {
+	
+public:  
+	
+	ofxGifFrame(){
+		pixels = NULL;
+	};
+	~ofxGifFrame(){
+		if(pixels) delete[] pixels;		
+	}
+	
+	unsigned char   * pixels;
+    int width;
+    int height;
+    float duration;  // seconds
+	int bitsPerPixel;
+	
+	
+};
+#endif


### PR DESCRIPTION
Hi Jesus,

I was working with your ofGifEncoder class for a project : www.uglitch.com

I added a clear function, and check that the unsigned char \* pixels that you're copying are correctly deleted.
Also added a stop() function for the thread when the saving is done.

But still, there are some problems - I noticed a very huge memory leak while trying to do various gifs one after another.

I've checked a lot of examples from FreeImage and everything seems to be ok.
All the allocations seems to be deleted..

See memory debugger if you're interested : http://dl.dropbox.com/u/817108/share/ofxGifEncoderMem.jpg

If you have any idea on this ? 
Maybe It's worth to write something on the OF forum 

Don't feel forced to merge this pull request, as this problem is still going on.

Also one good improvement would be to make ofxGifEncoder and ofxGifDecoder more compatible, if you want I would be happy to help on that

Saludos!
