### PR TITLE
Getter for ofImage properties (0.9 compatibility)

### DIFF
--- a/src/ofxGifEncoder.cpp
+++ b/src/ofxGifEncoder.cpp
@@ -48,12 +48,12 @@ ofxGifFrame * ofxGifEncoder::createGifFrame(unsigned char * px, int _w, int _h, 
 
 void ofxGifEncoder::addFrame(ofImage & img, float _duration) {
 
-    if(img.width != w || img.height != h) {
+    if(img.getWidth() != w || img.getHeight() != h) {
         ofLog(OF_LOG_WARNING, "ofxGifEncoder::addFrame image dimensions don't match, skipping frame");
         return;
     }
     
-    addFrame(img.getPixels(), w, h, img.bpp,  _duration);
+    addFrame(img.getPixels(), w, h, img.getPixels().getBitsPerPixel(),  _duration);
 }
 
 void ofxGifEncoder::addFrame(unsigned char *px, int _w, int _h, int _bitsPerPixel, float _duration) {


### PR DESCRIPTION
In oF 0.9 the height, weight and bpp properties of ofImage are protected. This PR fixes the issue.