### PR TITLE
Removes unnecessary include

### DIFF
--- a/src/ofxGifEncoder.h
+++ b/src/ofxGifEncoder.h
@@ -10,7 +10,6 @@
 
 #include "ofMain.h"
 #include "FreeImage.h"
-#include "ofxGifFrame.h"
 #include "ofxGifDitherTypes.h"
 
 #pragma once


### PR DESCRIPTION
@BaptisteTheoriz created [this commit](https://github.com/jesusgollonet/ofxGifEncoder/commit/e30b41312cedbd967984ee798090720cd05a194f) to prevent name conflicts with ofxGifDecoder. However if the include is left in then this addon no longer compiles *without* ofxGifDecoder!