### PR TITLE
Palette has to be cleared for each frame

### DIFF
--- a/src/ofxGifEncoder.cpp
+++ b/src/ofxGifEncoder.cpp
@@ -53,7 +53,7 @@ void ofxGifEncoder::addFrame(ofImage & img, float _duration) {
         return;
     }
     
-    addFrame(img.getPixels(), w, h, img.getPixels().getBitsPerPixel(),  _duration);
+    addFrame(img.getPixels().getData(), w, h, img.getPixels().getBitsPerPixel(),  _duration);
 }
 
 void ofxGifEncoder::addFrame(unsigned char *px, int _w, int _h, int _bitsPerPixel, float _duration) {

--- a/src/ofxGifEncoder.cpp
+++ b/src/ofxGifEncoder.cpp
@@ -141,6 +141,7 @@ void ofxGifEncoder::doSave() {
 void ofxGifEncoder::calculatePalette(FIBITMAP * bmp){
     RGBQUAD *pal = FreeImage_GetPalette(bmp);
     
+	palette.clear();
     for (int i = 0; i < 256; i++) {
         palette.push_back(ofColor(pal[i].rgbRed, pal[i].rgbGreen, pal[i].rgbBlue));
         ofLog() << palette.at(i);

--- a/src/ofxGifEncoder.h
+++ b/src/ofxGifEncoder.h
@@ -10,7 +10,6 @@
 
 #include "ofMain.h"
 #include "FreeImage.h"
-#include "ofxGifFrame.h"
 #include "ofxGifDitherTypes.h"
 
 #pragma once

--- a/src/ofxGifEncoder.h
+++ b/src/ofxGifEncoder.h
@@ -38,7 +38,7 @@ class ofxGifEncoder: public ofThread {
 
         // thread saving
         // blocking, verbose
-        void start() {startThread(true, false);}
+        void start() {startThread();}
         void stop() {stopThread();}
         void exit();
 		void reset();


### PR DESCRIPTION
Palette has to be cleared for each frame for exporting GIF with transparent background. Otherwise, the transparent color index would not be right in the following frames